### PR TITLE
moved ingestor functions in container & upload cls

### DIFF
--- a/hxm_rag/database/ingestion/ingestor.py
+++ b/hxm_rag/database/ingestion/ingestor.py
@@ -4,11 +4,65 @@ from hxm_rag.model.model.block import Block
 from hxm_rag.model.model.doc import Doc
 from hxm_rag.utils.model.block import separate_1_block_in_n
 
+# TODO currently the ingestor only ingests summaries
+# ADD ingestion method to the method call
+# pass data to ingestor to ingest...
 
-class Ingestor:
+# class DocumentProcessor: # TODO -> all functionality moved to container
+#     def __init__(self, doc_container, llmagent):
+#         if not isinstance(llmagent, LlmAgent) and llmagent is not None:
+#             raise TypeError("llmagent should be a LlmAgent")
+#         self.doc_container = doc_container
+#         self.llmagent = llmagent
+
+#     def process_document(self):
+#         for block in self.doc_container.blocks:
+#             self.process_block(block)
+
+#     def process_block(self, block):
+#         if len(block.content) > 4000:
+#             new_blocks = separate_1_block_in_n(block, max_size=3000)
+#             for new_block in new_blocks:
+#                 self.summarize(new_block)
+#         else:
+#             self.summarize(block)
+
+#     def summarize(self, block):
+#         summary = self.llmagent.summarize_paragraph(
+#             prompt=block.content,
+#             title_doc=self.doc_container.title,
+#             title_para=block.title,
+#         )
+#         summary = summary.split("<summary>")[1] if "<summary>" in summary else summary
+#         embedded_summary = self.llmagent.get_embedding(summary)
+
+#         # Return the summary and embedded summary for storage
+#         return summary, embedded_summary, block
+
+
+# replaces upload functions
+ 
+class DocumentUploader:
+    def __init__(self, clientdb):
+        self.clientdb = clientdb
+
+    def upload_document(self, summarized_docs, embedded_summaries, block_list):
+        for summary, embedded_summary, block in zip(summarized_docs, embedded_summaries, block_list):
+            self.clientdb.add_document(summary, embedded_summary, block)
+
+
+# def main_rag():
+
+#     for block in doc_container.blocks:
+#         summary, embedded_summary, processed_block = processor.summarize_and_store(block)
+#         uploader.upload_document(summary, embedded_summary, processed_block)
+        
+###############OLD###################################
+##########################################################################
+class Uploader:
     """
-    Ingestor class that serves as the ingestion part of the RAG system
-    Responsible for ingesting documents relevant to input query  
+    Uploader class that serves as the upload part of the RAG system
+    Responsible for uploading documents relevant to input query  
     Attributes:
     - doc_container: doc.container # TODO
     - collection: # TODO
@@ -17,7 +71,10 @@ class Ingestor:
     """
 
     def __init__(
-        self, clientdb: IDbClient, doc_container: Doc = None, llmagent: LlmAgent = None
+        self, 
+        clientdb: IDbClient, 
+        doc_container: Doc = None, 
+        llmagent: LlmAgent = None
     ):
         # if not isinstance(doc_container, Doc.container) and doc_container is not None: # TODO
         #     raise TypeError("doc should be a Doc")
@@ -28,6 +85,7 @@ class Ingestor:
         self.doc_container = doc_container
         self.clientdb = clientdb
         self.llmagent = llmagent
+        self.summary = None
         if self.doc_container:
             self.process_document()
 
@@ -77,7 +135,7 @@ class Ingestor:
         embedded_summary = self.llmagent.get_embedding(summary)
 
         self.clientdb.add_document(summary, embedded_summary, block)
-        print(summary)
+        self.summary = summary
 
     ########################Summarize by Hierarchy fcts#####################################
     def create_hierarchy(self, blocks) -> dict:
@@ -112,7 +170,7 @@ class Ingestor:
             )
         }
 
-    def summarize_by_hierarchy(self):
+    def summarize_by_hierarchy(self): #unused currently
         """
         Summarizes blocks based on their hierarchical levels.
         """

--- a/test/test_integration/test_main.py
+++ b/test/test_integration/test_main.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from hxm_rag.initializer.initializer import Initializer
-from hxm_rag.database.ingestion.ingestor import Ingestor
+from hxm_rag.database.ingestion.ingestor import DocumentUploader
 from hxm_rag.llm.llm.LlmAgent import LlmAgent
 from hxm_rag.retriever.retriever import Retriever
 from hxm_rag.model.model.doc import Doc 
@@ -15,24 +15,25 @@ load_dotenv()
 
 def test_llm_agent_setup():
     # test llm agent properties etc 
-    # TODO implement for other llms agents than openai
+    # TODO implement for other llms agents than openai (in confest)
     pass
 
 def test_db_adapter_setup():
-    # TODO implement for other databases
+    # TODO implement for other databases (in confest)
     pass
 
 def test_whole_thing(llm_agent_setup, db_adapter_setup):
     doc = Doc(path="data/test_data/SampleData.xlsx", 
             include_images = False, 
             actual_first_page = 1)
-     
-    ingestor = Ingestor(doc_container = doc.container, 
-                        clientdb = db_adapter_setup,
-                        llmagent = llm_agent_setup) 
+
+    summarized_docs, embedded_summaries, block_list = doc.container.process_document(llm_agent_setup) 
+    uploader = DocumentUploader(db_adapter_setup)
+    uploader.upload_document(summarized_docs, embedded_summaries, block_list)
     
     # TODO check that document is in the database
     # TODO check that the summary is correctly being generated
+    # TODO fix paragraph title coming out as an object
     retriever = Retriever(collection = db_adapter_setup.collection, 
                         llmagent = llm_agent_setup)
      # TODO check retriever algorithm


### PR DESCRIPTION
 Processing and uploading fncts previously handled by the ingestor class have now been moved to the container class and a DocumentUploader class currently inside the ingestor.py file. 

Usage is as follows and can be found in the test_main.py file.
```
summarized_docs, embedded_summaries, block_list = doc.container.process_document(llm_agent_setup) 
uploader = DocumentUploader(db_adapter_setup)
uploader.upload_document(summarized_docs, embedded_summaries, block_list)
```